### PR TITLE
Rewrite watchlist builder module

### DIFF
--- a/src/core_modules/watchlist_management/__init__.py
+++ b/src/core_modules/watchlist_management/__init__.py
@@ -1,5 +1,9 @@
 """Watchlist management utilities."""
 
-from .watchlist_builder import build_watchlist, simulate_data_stream
+from .watchlist_builder import (
+    build_watchlist,
+    simulate_data_stream,
+    app,
+)
 
-__all__ = ["build_watchlist", "simulate_data_stream"]
+__all__ = ["build_watchlist", "simulate_data_stream", "app"]

--- a/src/core_modules/watchlist_management/watchlist_builder.py
+++ b/src/core_modules/watchlist_management/watchlist_builder.py
@@ -1,8 +1,20 @@
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from typing import Dict, Iterable, Generator, List, Optional
 
+import argparse
+import csv
+import json
+
+import numpy as np
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
 
 def simulate_data_stream(data: Iterable[Dict]) -> Generator[Dict, None, None]:
     """Yield items from ``data`` simulating a real-time stream."""
@@ -11,31 +23,33 @@ def simulate_data_stream(data: Iterable[Dict]) -> Generator[Dict, None, None]:
 
 
 def _price_change_percentage(prices: List[float]) -> float:
-    """Return the percentage price change over the provided series."""
-    if len(prices) < 2:
+    """Return the percentage change from first to last price."""
+    if len(prices) < 2 or prices[0] == 0:
         return 0.0
-    start = prices[0]
-    end = prices[-1]
-    if start == 0:
-        return 0.0
-    return (end - start) / start * 100
+    return (prices[-1] - prices[0]) / prices[0] * 100
 
 
 def _volume_spike_ratio(volumes: List[float]) -> float:
-    """Return the ratio of the last day's volume to the average of the prior days."""
+    """Return the ratio of last volume to the average of prior volumes."""
     if len(volumes) < 2:
         return 0.0
     *prior, last = volumes
-    avg_prior = sum(prior) / len(prior)
-    if avg_prior == 0:
+    avg = sum(prior) / len(prior)
+    if avg == 0:
         return 0.0
-    return last / avg_prior
+    return last / avg
 
+
+# ---------------------------------------------------------------------------
+# Core functionality
+# ---------------------------------------------------------------------------
 
 def build_watchlist(
     data_stream: Iterable[Dict],
-    manual_overrides: Optional[Iterable[str]] = None,
+    include: Optional[Iterable[str]] = None,
+    exclude: Optional[Iterable[str]] = None,
     current_date: Optional[date] = None,
+    log_file: Optional[str] = None,
 ) -> List[str]:
     """Filter stocks from ``data_stream`` based on multiple criteria.
 
@@ -43,52 +57,155 @@ def build_watchlist(
     ----------
     data_stream:
         Iterable of dictionaries representing stock data. Expected keys:
-        ``symbol`` (str), ``market_cap`` (float in Cr), ``price_history`` (list
-        of floats with at least 5 entries), ``volume_history`` (list of floats
-        with at least 10 entries), ``average_daily_value`` (float in Cr), and
-        ``ex_dividend_date`` (``datetime.date`` or ``datetime``).
-    manual_overrides:
-        Iterable of symbols that should always be included.
+        ``symbol`` (str), ``sector_strength`` (float), ``market_cap`` (float in Cr),
+        ``price_history`` (list of floats with at least 6 entries),
+        ``volume_history`` (list of floats with at least 10 entries),
+        ``average_daily_value`` (float in Cr), and ``ex_dividend_date``
+        (``datetime.date`` or ``datetime``).
+    include:
+        Symbols that must be included regardless of filters.
+    exclude:
+        Symbols that must be excluded regardless of filters.
     current_date:
         Date used for ex-dividend filtering. Defaults to today.
+    log_file:
+        Optional path to log reasons for exclusion.
 
     Returns
     -------
     List[str]
-        Symbols that satisfy all filters or are manually overridden.
+        Symbols passing all filters and any manually included symbols.
     """
-    current_date = current_date or datetime.utcnow().date()
-    overrides = set(manual_overrides or [])
+    records = list(data_stream)
+    if not records:
+        return []
 
-    eligible = []
-    for stock in data_stream:
+    current_date = current_date or datetime.utcnow().date()
+    include_set = set(include or [])
+    exclude_set = set(exclude or [])
+
+    strengths = [float(r.get("sector_strength", 0)) for r in records]
+    threshold = float(np.percentile(strengths, 75)) if strengths else 0.0
+
+    log_entries: List[str] = []
+    eligible: List[str] = []
+    for stock in records:
         symbol = stock.get("symbol")
-        if symbol in overrides:
+        if not symbol:
+            continue
+        if symbol in exclude_set:
+            log_entries.append(f"{symbol}: manually excluded")
+            continue
+        if symbol in include_set:
             eligible.append(symbol)
             continue
 
-        if stock.get("market_cap", 0) < 10000:
+        if float(stock.get("sector_strength", 0)) <= threshold:
+            log_entries.append(f"{symbol}: sector strength below 75th percentile")
             continue
-
-        if stock.get("average_daily_value", 0) < 5:
+        if float(stock.get("market_cap", 0)) <= 10000:
+            log_entries.append(f"{symbol}: market cap below threshold")
             continue
-
+        if float(stock.get("average_daily_value", 0)) < 5:
+            log_entries.append(f"{symbol}: ADV below threshold")
+            continue
         ex_date = stock.get("ex_dividend_date")
         if ex_date is not None:
             ex_date = ex_date.date() if isinstance(ex_date, datetime) else ex_date
-            days_to_ex = (ex_date - current_date).days
-            if 0 <= days_to_ex <= 2:
+            if 0 <= (ex_date - current_date).days <= 2:
+                log_entries.append(f"{symbol}: ex-dividend within 2 days")
                 continue
-
-        price_history = stock.get("price_history", [])[-6:]
-        if _price_change_percentage(price_history) <= 3 and _price_change_percentage(price_history) >= -3:
+        price_history = list(stock.get("price_history", []))[-6:]
+        change = _price_change_percentage(price_history)
+        if abs(change) <= 3:
+            log_entries.append(f"{symbol}: price change {change:.2f}% not strong")
             continue
-
-        volume_history = stock.get("volume_history", [])[-10:]
+        volume_history = list(stock.get("volume_history", []))[-10:]
         if _volume_spike_ratio(volume_history) <= 2:
+            log_entries.append(f"{symbol}: volume spike not significant")
             continue
-
         eligible.append(symbol)
+
+    if log_file:
+        with open(log_file, "w", encoding="utf-8") as f:
+            for entry in log_entries:
+                f.write(entry + "\n")
 
     return eligible
 
+
+# ---------------------------------------------------------------------------
+# Data loading helpers
+# ---------------------------------------------------------------------------
+
+def load_stock_data(path: str) -> List[Dict]:
+    """Load stock data from a JSON or CSV file."""
+    with open(path, "r", encoding="utf-8") as f:
+        if path.lower().endswith(".json"):
+            return json.load(f)
+        reader = csv.DictReader(f)
+        rows = []
+        for row in reader:
+            if "price_history" in row and isinstance(row["price_history"], str):
+                row["price_history"] = json.loads(row["price_history"])
+            if "volume_history" in row and isinstance(row["volume_history"], str):
+                row["volume_history"] = json.loads(row["volume_history"])
+            if row.get("ex_dividend_date"):
+                row["ex_dividend_date"] = datetime.fromisoformat(row["ex_dividend_date"]).date()
+            rows.append(row)
+        return rows
+
+def load_override_list(path: str) -> List[str]:
+    """Load a list of symbols from a text file."""
+    with open(path, "r", encoding="utf-8") as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Build stock watchlist")
+    parser.add_argument("--data", required=True, help="Path to stock data JSON/CSV")
+    parser.add_argument("--include", help="File with tickers to include")
+    parser.add_argument("--exclude", help="File with tickers to exclude")
+    parser.add_argument("--output", help="Where to write resulting watchlist JSON")
+    parser.add_argument("--log", help="Optional log file for exclusions")
+    args = parser.parse_args(argv)
+
+    data = load_stock_data(args.data)
+    include = load_override_list(args.include) if args.include else None
+    exclude = load_override_list(args.exclude) if args.exclude else None
+
+    watchlist = build_watchlist(data, include, exclude, log_file=args.log)
+    output = json.dumps(watchlist)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(output)
+    else:
+        print(output)
+
+
+# ---------------------------------------------------------------------------
+# FastAPI application
+# ---------------------------------------------------------------------------
+
+app = FastAPI()
+
+
+class WatchlistRequest(BaseModel):
+    stocks: List[Dict]
+    include: Optional[List[str]] = None
+    exclude: Optional[List[str]] = None
+
+
+@app.post("/build_watchlist")
+def build_watchlist_endpoint(req: WatchlistRequest) -> Dict[str, List[str]]:
+    tickers = build_watchlist(req.stocks, req.include, req.exclude)
+    return {"tickers": tickers}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/tests/test_watchlist_builder.py
+++ b/tests/test_watchlist_builder.py
@@ -1,70 +1,93 @@
-import sys, os
+import sys
+import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 import datetime
-from core_modules.watchlist_management import build_watchlist, simulate_data_stream
+from core_modules.watchlist_management import build_watchlist
+
+
+def _generate_dataset():
+    today = datetime.date.today()
+    data = []
+    # 10 stocks that meet all filters
+    for i in range(10):
+        data.append({
+            "symbol": f"PASS{i}",
+            "sector_strength": 90,
+            "market_cap": 12000,
+            "price_history": [100, 102, 103, 104, 105, 108],
+            "volume_history": [1] * 9 + [3],
+            "average_daily_value": 6,
+            "ex_dividend_date": today + datetime.timedelta(days=5),
+        })
+    # 90 stocks failing various filters
+    for i in range(90):
+        data.append({
+            "symbol": f"FAIL{i}",
+            "sector_strength": 40,
+            "market_cap": 5000,
+            "price_history": [100] * 6,
+            "volume_history": [1] * 10,
+            "average_daily_value": 4,
+            "ex_dividend_date": today + datetime.timedelta(days=1),
+        })
+    return data
 
 
 def test_build_watchlist_filters_correctly():
+    data = _generate_dataset()
+    result = build_watchlist(data)
+    assert len(result) == 10
+    assert set(result) == {f"PASS{i}" for i in range(10)}
+
+
+def test_empty_input_returns_empty_list():
+    assert build_watchlist([]) == []
+
+
+def test_all_tickers_failing_logged(tmp_path):
     today = datetime.date.today()
     data = [
         {
             "symbol": "AAA",
-            "market_cap": 15000,
-            "price_history": [100, 102, 103, 104, 105, 108],
-            "volume_history": [1, 1, 1, 1, 1, 1, 1, 1, 1, 3],
-            "average_daily_value": 6,
-            "ex_dividend_date": today + datetime.timedelta(days=5),
+            "sector_strength": 10,
+            "market_cap": 5000,
+            "price_history": [100] * 6,
+            "volume_history": [1] * 10,
+            "average_daily_value": 1,
+            "ex_dividend_date": today + datetime.timedelta(days=1),
         },
         {
             "symbol": "BBB",
-            "market_cap": 8000,  # below market cap threshold
-            "price_history": [100, 97, 96, 95, 94, 93],
+            "sector_strength": 20,
+            "market_cap": 4000,
+            "price_history": [100] * 6,
             "volume_history": [1] * 10,
-            "average_daily_value": 6,
-            "ex_dividend_date": today + datetime.timedelta(days=5),
-        },
-        {
-            "symbol": "CCC",
-            "market_cap": 12000,
-            "price_history": [100, 100, 100, 100, 100, 100],  # no price change
-            "volume_history": [1] * 9 + [5],
-            "average_daily_value": 6,
-            "ex_dividend_date": today + datetime.timedelta(days=5),
-        },
-        {
-            "symbol": "DDD",
-            "market_cap": 12000,
-            "price_history": [100, 102, 103, 104, 105, 106],
-            "volume_history": [1] * 9 + [3],
-            "average_daily_value": 4,  # below ADV threshold
-            "ex_dividend_date": today + datetime.timedelta(days=5),
-        },
-        {
-            "symbol": "EEE",
-            "market_cap": 15000,
-            "price_history": [100, 102, 103, 104, 105, 108],
-            "volume_history": [1] * 9 + [3],
-            "average_daily_value": 6,
-            "ex_dividend_date": today + datetime.timedelta(days=1),  # ex-div soon
+            "average_daily_value": 2,
+            "ex_dividend_date": today + datetime.timedelta(days=1),
         },
     ]
-    stream = simulate_data_stream(data)
-    result = build_watchlist(stream)
-    assert result == ["AAA"]
+    log_path = tmp_path / "log.txt"
+    result = build_watchlist(data, log_file=str(log_path))
+    assert result == []
+    lines = log_path.read_text().strip().splitlines()
+    assert len(lines) == len(data)
+    assert all(line.startswith(("AAA", "BBB")) for line in lines)
 
 
-def test_manual_overrides_always_include():
+def test_manual_overrides_include_and_exclude():
     today = datetime.date.today()
     data = [
         {
-            "symbol": "ZZZ",
+            "symbol": "OVR",
+            "sector_strength": 10,
             "market_cap": 5000,
-            "price_history": [100, 100, 100, 100, 100, 100],
+            "price_history": [100] * 6,
             "volume_history": [1] * 10,
             "average_daily_value": 1,
             "ex_dividend_date": today + datetime.timedelta(days=1),
         }
     ]
-    stream = simulate_data_stream(data)
-    result = build_watchlist(stream, manual_overrides=["ZZZ"])
-    assert result == ["ZZZ"]
+    result = build_watchlist(data, include=["OVR"])
+    assert result == ["OVR"]
+    result = build_watchlist(data, exclude=["OVR"])
+    assert result == []


### PR DESCRIPTION
## Summary
- rebuild watchlist builder with advanced filtering logic
- expose CLI and FastAPI endpoint
- update module exports
- add comprehensive tests for new behaviour

## Testing
- `pip install numpy==1.26.4 pandas==2.2.2 -q` *(fails: Could not connect to proxy)*
- `pytest tests/test_watchlist_builder.py -q` *(fails: ModuleNotFoundError for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_685c16ad7c988322ae667256511fd0b4