### PR TITLE
Fix tests by adding src path

### DIFF
--- a/tests/test_fundamental_screener.py
+++ b/tests/test_fundamental_screener.py
@@ -1,5 +1,10 @@
+import os
+import sys
+
 import pandas as pd
-from src.core_modules.screening.fundamental_screener import fundamental_screener
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+from core_modules.screening.fundamental_screener import fundamental_screener
 
 
 def test_fundamental_screener_basic():


### PR DESCRIPTION
## Summary
- fix path import in fundamental screener tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cbc91e9b48322ae6e169e16b745ee