### PR TITLE
Implement L3 Invariant 3: Regime-Aware Trust Adjustment

### DIFF
--- a/src/intelligence/meta_analysis.py
+++ b/src/intelligence/meta_analysis.py
@@ -5,6 +5,7 @@ Responsibility: Consolidate intelligence and enforce regime dependency.
 """
 from typing import Dict, Any, Optional
 from datetime import datetime
+from traderfund.regime.types import MarketBehavior
 
 class MetaAnalysis:
     """
@@ -15,9 +16,27 @@ class MetaAnalysis:
         self.status = "PENDING"
         self.regime_state = None
 
-    def analyze(self, regime_state: Optional[Dict[str, Any]] = None, **kwargs) -> Dict[str, Any]:
+    def _get_regime_category(self, behavior: Any) -> str:
+        """
+        Classifies MarketBehavior into CHOP, TRANSITION, or TRENDING.
+        """
+        # Ensure behavior is compared correctly whether it's string or Enum
+        if behavior in [MarketBehavior.MEAN_REVERTING_LOW_VOL, MarketBehavior.MEAN_REVERTING_HIGH_VOL]:
+            return "CHOP"
+        elif behavior in [MarketBehavior.TRENDING_NORMAL_VOL, MarketBehavior.TRENDING_HIGH_VOL]:
+            return "TRENDING"
+        else:
+            return "TRANSITION"
+
+    def analyze(self,
+                regime_state: Optional[Dict[str, Any]] = None,
+                technical_breakout_trust: float = 0.0,
+                momentum_trust: float = 0.0,
+                factor_alignment: bool = False,
+                **kwargs) -> Dict[str, Any]:
         """
         Perform meta-analysis with strict regime dependency check (L3 Invariant 01).
+        And Invariant 3: Regime-Aware Trust Adjustment.
         """
         # Invariant 01 - Regime Dependency
         if not regime_state:
@@ -30,6 +49,39 @@ class MetaAnalysis:
             }
 
         self.regime_state = regime_state
+
+        # Extract behavior from regime_state
+        behavior = regime_state.get("behavior")
+
+        # Default to UNDEFINED if not present (handled as TRANSITION)
+        if not behavior:
+            behavior = MarketBehavior.UNDEFINED
+
+        regime_category = self._get_regime_category(behavior)
+
+        # Invariant 3 — Regime-Aware Trust Adjustment
+        # In CHOP or TRANSITION regime: Technical breakout trust ≤ 0.50
+        if regime_category in ["CHOP", "TRANSITION"]:
+            if technical_breakout_trust > 0.50:
+                self.trust_score = 0.0
+                self.status = "REJECTED"
+                return {
+                    "trust_score": self.trust_score,
+                    "status": self.status,
+                    "reason": f"Invariant 3 Violation: Breakout trust {technical_breakout_trust} > 0.50 in {regime_category} ({behavior})."
+                }
+
+        # In TRENDING regime: Momentum trust ≥ 0.60 IF factor alignment present
+        if regime_category == "TRENDING":
+            if factor_alignment and momentum_trust < 0.60:
+                self.trust_score = 0.0
+                self.status = "REJECTED"
+                return {
+                    "trust_score": self.trust_score,
+                    "status": self.status,
+                    "reason": f"Invariant 3 Violation: Momentum trust {momentum_trust} < 0.60 in TRENDING ({behavior}) with factor alignment."
+                }
+
         self.status = "ACTIVE"
         # Placeholder for actual meta-analysis logic
         self.trust_score = 1.0 # Mock success if context provided

--- a/tests/test_meta_analysis.py
+++ b/tests/test_meta_analysis.py
@@ -1,5 +1,6 @@
 import pytest
 from src.intelligence.meta_analysis import MetaAnalysis
+from traderfund.regime.types import MarketBehavior
 
 def test_meta_analysis_no_context():
     ma = MetaAnalysis()
@@ -11,8 +12,85 @@ def test_meta_analysis_no_context():
 
 def test_meta_analysis_with_context():
     ma = MetaAnalysis()
-    regime = {"bias": "BULLISH", "confidence": 0.9}
+    # Provide behavior for robustness, though code defaults to UNDEFINED
+    regime = {"bias": "BULLISH", "confidence": 0.9, "behavior": MarketBehavior.TRENDING_NORMAL_VOL}
     result = ma.analyze(regime_state=regime)
     assert result["trust_score"] > 0.0
     assert result["status"] == "ACTIVE"
     assert ma.regime_state == regime
+
+def test_invariant3_chop_rejection():
+    """
+    In CHOP or TRANSITION regime: Technical breakout trust ≤ 0.50
+    """
+    ma = MetaAnalysis()
+    regime = {"behavior": MarketBehavior.MEAN_REVERTING_LOW_VOL} # CHOP
+
+    # Violation: trust > 0.50
+    result = ma.analyze(
+        regime_state=regime,
+        technical_breakout_trust=0.51
+    )
+    assert result["status"] == "REJECTED"
+    assert result["trust_score"] == 0.0
+    assert "Invariant 3 Violation" in result["reason"]
+
+    # Success: trust <= 0.50
+    result = ma.analyze(
+        regime_state=regime,
+        technical_breakout_trust=0.50
+    )
+    assert result["status"] == "ACTIVE"
+
+def test_invariant3_transition_rejection():
+    """
+    In CHOP or TRANSITION regime: Technical breakout trust ≤ 0.50
+    """
+    ma = MetaAnalysis()
+    regime = {"behavior": MarketBehavior.UNDEFINED} # TRANSITION
+
+    # Violation: trust > 0.50
+    result = ma.analyze(
+        regime_state=regime,
+        technical_breakout_trust=0.60
+    )
+    assert result["status"] == "REJECTED"
+
+    # Success
+    result = ma.analyze(
+        regime_state=regime,
+        technical_breakout_trust=0.40
+    )
+    assert result["status"] == "ACTIVE"
+
+def test_invariant3_trending_momentum():
+    """
+    In TRENDING regime: Momentum trust ≥ 0.60 IF factor alignment present
+    """
+    ma = MetaAnalysis()
+    regime = {"behavior": MarketBehavior.TRENDING_NORMAL_VOL} # TRENDING
+
+    # Violation: factor alignment present, momentum trust < 0.60
+    result = ma.analyze(
+        regime_state=regime,
+        momentum_trust=0.59,
+        factor_alignment=True
+    )
+    assert result["status"] == "REJECTED"
+    assert "Invariant 3 Violation" in result["reason"]
+
+    # Success: factor alignment present, momentum trust >= 0.60
+    result = ma.analyze(
+        regime_state=regime,
+        momentum_trust=0.60,
+        factor_alignment=True
+    )
+    assert result["status"] == "ACTIVE"
+
+    # Success: no factor alignment, momentum trust can be anything (e.g. low)
+    result = ma.analyze(
+        regime_state=regime,
+        momentum_trust=0.20,
+        factor_alignment=False
+    )
+    assert result["status"] == "ACTIVE"


### PR DESCRIPTION
Implemented Invariant 3 in src/intelligence/meta_analysis.py which enforces regime-dependent trust thresholds. In CHOP/TRANSITION regimes, technical breakout trust must be <= 0.50. In TRENDING regimes, momentum trust must be >= 0.60 if factor alignment is present. Added tests in tests/test_meta_analysis.py covering these scenarios.

---
*PR created automatically by Jules for task [11650793064624646431](https://jules.google.com/task/11650793064624646431) started by @sakettamrakar*